### PR TITLE
Avoid verify_signature error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ cover_db/
 *.swp
 *.o
 *.obj
+.idea
 
 !LICENSE
 

--- a/Changes
+++ b/Changes
@@ -2,10 +2,9 @@ Revision history for Perl extension WebService-SOP-Auth-V1_1
 
 {{$NEXT}}
 
-0.05 2022-12-28T02:54:00Z
-
     - Catch verify_signature errors
     - Remove Test::Pretty
+    - Rename namespace to WebService::DS::SOP::Auth
 
 0.04 2016-03-09T07:02:11Z
 

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension WebService-SOP-Auth-V1_1
 
 {{$NEXT}}
 
+0.05 2023-01-06T06:06:49Z
+
     - Catch verify_signature errors
     - Remove Test::Pretty
     - Rename namespace to WebService::DS::SOP::Auth

--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Perl extension WebService-SOP-Auth-V1_1
 
 {{$NEXT}}
 
+0.05 2022-12-28T02:54:00Z
+
+    - Catch verify_signature errors
+    - Remove Test::Pretty
+
 0.04 2016-03-09T07:02:11Z
 
     - Perl >= 5.10

--- a/META.json
+++ b/META.json
@@ -4,15 +4,15 @@
       "yowcow <yoko.oyama [ at ] d8aspring.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v3.0.1, CPAN::Meta::Converter version 2.150005",
+   "generated_by" : "Minilla/v3.1.20, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
    "meta-spec" : {
       "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
-      "version" : "2"
+      "version" : 2
    },
-   "name" : "WebService-SOP-Auth-V1_1",
+   "name" : "WebService-DS-SOP-Auth-V1_1",
    "no_index" : {
       "directory" : [
          "t",
@@ -35,7 +35,7 @@
          "requires" : {
             "Test::CPAN::Meta" : "0",
             "Test::MinimumVersion::Fast" : "0.04",
-            "Test::PAUSE::Permissions" : "0.04",
+            "Test::PAUSE::Permissions" : "0.07",
             "Test::Pod" : "1.41",
             "Test::Spellunker" : "v0.2.7"
          }
@@ -57,7 +57,6 @@
             "Test::More" : "0.98",
             "Test::Perl::Critic" : "0",
             "Test::Pod::Coverage" : "0",
-            "Test::Pretty" : "0",
             "Test::Stub" : "0"
          }
       }
@@ -70,18 +69,19 @@
       "homepage" : "https://github.com/researchpanelasia/p5-WebService-SOP-Auth-V1_1",
       "repository" : {
          "type" : "git",
-         "url" : "git://github.com/researchpanelasia/p5-WebService-SOP-Auth-V1_1.git",
+         "url" : "https://github.com/researchpanelasia/p5-WebService-SOP-Auth-V1_1.git",
          "web" : "https://github.com/researchpanelasia/p5-WebService-SOP-Auth-V1_1"
       }
    },
    "version" : "0.05",
-   "x_authority" : "cpan:YOWCOW",
+   "x_authority" : "cpan:DSSYSTEM",
    "x_contributors" : [
-      "t-sekiguchi <Takafumi_Sekiguchi@voyagegroup.com>",
-      "yowcowvg <yoko_ohyama@voyagegroup.com>",
-      "yowcow <yowcow@cpan.org>",
+      "Jamerswu <jamers.wu@d8aspring.com>",
       "Yoko OYAMA <yowcow@users.noreply.github.com>",
-      "Jamers Wu <jamers.wu@d8aspring.com>"
+      "t-sekiguchi <Takafumi_Sekiguchi@voyagegroup.com>",
+      "yowcow <yowcow@cpan.org>",
+      "yowcowvg <yoko_ohyama@voyagegroup.com>"
    ],
-   "x_serialization_backend" : "JSON::PP version 2.27300"
+   "x_serialization_backend" : "JSON::PP version 4.16",
+   "x_static_install" : 1
 }

--- a/META.json
+++ b/META.json
@@ -74,13 +74,14 @@
          "web" : "https://github.com/researchpanelasia/p5-WebService-SOP-Auth-V1_1"
       }
    },
-   "version" : "0.04",
+   "version" : "0.05",
    "x_authority" : "cpan:YOWCOW",
    "x_contributors" : [
       "t-sekiguchi <Takafumi_Sekiguchi@voyagegroup.com>",
       "yowcowvg <yoko_ohyama@voyagegroup.com>",
       "yowcow <yowcow@cpan.org>",
-      "Yoko OYAMA <yowcow@users.noreply.github.com>"
+      "Yoko OYAMA <yowcow@users.noreply.github.com>",
+      "Jamers Wu <jamers.wu@d8aspring.com>"
    ],
    "x_serialization_backend" : "JSON::PP version 2.27300"
 }

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 [![Build Status](https://travis-ci.org/researchpanelasia/p5-WebService-SOP-Auth-V1_1.svg?branch=master)](https://travis-ci.org/researchpanelasia/p5-WebService-SOP-Auth-V1_1)
 # NAME
 
-WebService::SOP::Auth::V1\_1 - SOP version 1.1 authentication module
+WebService::DS::SOP::Auth::V1\_1 - SOP version 1.1 authentication module
 
 # SYNOPSIS
 
-    use WebService::SOP::Auth::V1_1;
+    use WebService::DS::SOP::Auth::V1_1;
 
 To create an instance:
 
-    my $auth = WebService::SOP::Auth::V1_1->new({
+    my $auth = WebService::DS::SOP::Auth::V1_1->new({
         app_id => '1',
         app_secret => 'hogehoge',
     });
@@ -42,13 +42,13 @@ When embedding JavaScript URL in page:
 
 # DESCRIPTION
 
-WebService::SOP::Auth::V1\_1 is an authentication module
+WebService::DS::SOP::Auth::V1\_1 is an authentication module
 for [SOP](http://console.partners.surveyon.com/) version 1.1
 by [Research Panel Asia, Inc](http://www.researchpanelasia.com/).
 
 # METHODS
 
-## new( \\%options ) returns WebService::SOP::Auth::V1\_1
+## new( \\%options ) returns WebService::DS::SOP::Auth::V1\_1
 
 Creates a new instance.
 
@@ -120,13 +120,13 @@ Verifies and returns if request signature is valid.
 
 # SEE ALSO
 
-[WebService::SOP::Auth::V1\_1::Request::DELETE](https://metacpan.org/pod/WebService::SOP::Auth::V1_1::Request::DELETE),
-[WebService::SOP::Auth::V1\_1::Request::GET](https://metacpan.org/pod/WebService::SOP::Auth::V1_1::Request::GET),
-[WebService::SOP::Auth::V1\_1::Request::POST](https://metacpan.org/pod/WebService::SOP::Auth::V1_1::Request::POST),
-[WebService::SOP::Auth::V1\_1::Request::POST\_JSON](https://metacpan.org/pod/WebService::SOP::Auth::V1_1::Request::POST_JSON),
-[WebService::SOP::Auth::V1\_1::Request::PUT](https://metacpan.org/pod/WebService::SOP::Auth::V1_1::Request::PUT),
-[WebService::SOP::Auth::V1\_1::Request::PUT\_JSON](https://metacpan.org/pod/WebService::SOP::Auth::V1_1::Request::PUT_JSON),
-[WebService::SOP::Auth::V1\_1::Util](https://metacpan.org/pod/WebService::SOP::Auth::V1_1::Util)
+[WebService::DS::SOP::Auth::V1\_1::Request::DELETE](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Request::DELETE),
+[WebService::DS::SOP::Auth::V1\_1::Request::GET](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Request::GET),
+[WebService::DS::SOP::Auth::V1\_1::Request::POST](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Request::POST),
+[WebService::DS::SOP::Auth::V1\_1::Request::POST\_JSON](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Request::POST_JSON),
+[WebService::DS::SOP::Auth::V1\_1::Request::PUT](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Request::PUT),
+[WebService::DS::SOP::Auth::V1\_1::Request::PUT\_JSON](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Request::PUT_JSON),
+[WebService::DS::SOP::Auth::V1\_1::Util](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Util)
 
 # LICENSE
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Returns `time` configured to instance.
 
 ## create\_request( Str $type, Any $uri, Hash $params ) returns HTTP::Request
 
-Returns a new [HTTP::Request](https://metacpan.org/pod/HTTP::Request) object for API request while adding `app_id` to parameters by default.
+Returns a new [HTTP::Request](https://metacpan.org/pod/HTTP%3A%3ARequest) object for API request while adding `app_id` to parameters by default.
 
 _$type_ can be one of followings:
 
@@ -120,13 +120,13 @@ Verifies and returns if request signature is valid.
 
 # SEE ALSO
 
-[WebService::DS::SOP::Auth::V1\_1::Request::DELETE](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Request::DELETE),
-[WebService::DS::SOP::Auth::V1\_1::Request::GET](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Request::GET),
-[WebService::DS::SOP::Auth::V1\_1::Request::POST](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Request::POST),
-[WebService::DS::SOP::Auth::V1\_1::Request::POST\_JSON](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Request::POST_JSON),
-[WebService::DS::SOP::Auth::V1\_1::Request::PUT](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Request::PUT),
-[WebService::DS::SOP::Auth::V1\_1::Request::PUT\_JSON](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Request::PUT_JSON),
-[WebService::DS::SOP::Auth::V1\_1::Util](https://metacpan.org/pod/WebService::DS::SOP::Auth::V1_1::Util)
+[WebService::DS::SOP::Auth::V1\_1::Request::DELETE](https://metacpan.org/pod/WebService%3A%3ADS%3A%3ASOP%3A%3AAuth%3A%3AV1_1%3A%3ARequest%3A%3ADELETE),
+[WebService::DS::SOP::Auth::V1\_1::Request::GET](https://metacpan.org/pod/WebService%3A%3ADS%3A%3ASOP%3A%3AAuth%3A%3AV1_1%3A%3ARequest%3A%3AGET),
+[WebService::DS::SOP::Auth::V1\_1::Request::POST](https://metacpan.org/pod/WebService%3A%3ADS%3A%3ASOP%3A%3AAuth%3A%3AV1_1%3A%3ARequest%3A%3APOST),
+[WebService::DS::SOP::Auth::V1\_1::Request::POST\_JSON](https://metacpan.org/pod/WebService%3A%3ADS%3A%3ASOP%3A%3AAuth%3A%3AV1_1%3A%3ARequest%3A%3APOST_JSON),
+[WebService::DS::SOP::Auth::V1\_1::Request::PUT](https://metacpan.org/pod/WebService%3A%3ADS%3A%3ASOP%3A%3AAuth%3A%3AV1_1%3A%3ARequest%3A%3APUT),
+[WebService::DS::SOP::Auth::V1\_1::Request::PUT\_JSON](https://metacpan.org/pod/WebService%3A%3ADS%3A%3ASOP%3A%3AAuth%3A%3AV1_1%3A%3ARequest%3A%3APUT_JSON),
+[WebService::DS::SOP::Auth::V1\_1::Util](https://metacpan.org/pod/WebService%3A%3ADS%3A%3ASOP%3A%3AAuth%3A%3AV1_1%3A%3AUtil)
 
 # LICENSE
 

--- a/cpanfile
+++ b/cpanfile
@@ -12,7 +12,6 @@ on 'test' => sub {
     requires 'Test::More', '>= 0.98';
     requires 'Test::Perl::Critic';
     requires 'Test::Pod::Coverage';
-    requires 'Test::Pretty';
     requires 'Test::Stub';
 };
 

--- a/lib/WebService/DS/SOP/Auth/V1_1.pm
+++ b/lib/WebService/DS/SOP/Auth/V1_1.pm
@@ -1,4 +1,4 @@
-package WebService::SOP::Auth::V1_1;
+package WebService::DS::SOP::Auth::V1_1;
 use 5.008001;
 use strict;
 use warnings;
@@ -7,13 +7,13 @@ our $VERSION = "0.05";
 
 use Carp ();
 use URI;
-use WebService::SOP::Auth::V1_1::Request::DELETE;
-use WebService::SOP::Auth::V1_1::Request::GET;
-use WebService::SOP::Auth::V1_1::Request::POST;
-use WebService::SOP::Auth::V1_1::Request::POST_JSON;
-use WebService::SOP::Auth::V1_1::Request::PUT;
-use WebService::SOP::Auth::V1_1::Request::PUT_JSON;
-use WebService::SOP::Auth::V1_1::Util qw(is_signature_valid);
+use WebService::DS::SOP::Auth::V1_1::Request::DELETE;
+use WebService::DS::SOP::Auth::V1_1::Request::GET;
+use WebService::DS::SOP::Auth::V1_1::Request::POST;
+use WebService::DS::SOP::Auth::V1_1::Request::POST_JSON;
+use WebService::DS::SOP::Auth::V1_1::Request::PUT;
+use WebService::DS::SOP::Auth::V1_1::Request::PUT_JSON;
+use WebService::DS::SOP::Auth::V1_1::Util qw(is_signature_valid);
 
 sub new {
     my ($class, $args) = @_;
@@ -36,7 +36,7 @@ sub time       { $_[0]->{time} }
 sub create_request {
     my ($self, $type, $uri, $params) = @_;
     $uri = URI->new($uri) if not ref $uri;
-    my $request_maker = "WebService::SOP::Auth::V1_1::Request::${type}";
+    my $request_maker = "WebService::DS::SOP::Auth::V1_1::Request::${type}";
     $request_maker->create_request($uri, { %$params, app_id => $self->app_id, time => $self->time },
         $self->app_secret,);
 }
@@ -53,15 +53,15 @@ __END__
 
 =head1 NAME
 
-WebService::SOP::Auth::V1_1 - SOP version 1.1 authentication module
+WebService::DS::SOP::Auth::V1_1 - SOP version 1.1 authentication module
 
 =head1 SYNOPSIS
 
-    use WebService::SOP::Auth::V1_1;
+    use WebService::DS::SOP::Auth::V1_1;
 
 To create an instance:
 
-    my $auth = WebService::SOP::Auth::V1_1->new({
+    my $auth = WebService::DS::SOP::Auth::V1_1->new({
         app_id => '1',
         app_secret => 'hogehoge',
     });
@@ -95,13 +95,13 @@ When embedding JavaScript URL in page:
 
 =head1 DESCRIPTION
 
-WebService::SOP::Auth::V1_1 is an authentication module
+WebService::DS::SOP::Auth::V1_1 is an authentication module
 for L<SOP|http://console.partners.surveyon.com/> version 1.1
 by L<Research Panel Asia, Inc|http://www.researchpanelasia.com/>.
 
 =head1 METHODS
 
-=head2 new( \%options ) returns WebService::SOP::Auth::V1_1
+=head2 new( \%options ) returns WebService::DS::SOP::Auth::V1_1
 
 Creates a new instance.
 
@@ -181,13 +181,13 @@ Verifies and returns if request signature is valid.
 
 =head1 SEE ALSO
 
-L<WebService::SOP::Auth::V1_1::Request::DELETE>,
-L<WebService::SOP::Auth::V1_1::Request::GET>,
-L<WebService::SOP::Auth::V1_1::Request::POST>,
-L<WebService::SOP::Auth::V1_1::Request::POST_JSON>,
-L<WebService::SOP::Auth::V1_1::Request::PUT>,
-L<WebService::SOP::Auth::V1_1::Request::PUT_JSON>,
-L<WebService::SOP::Auth::V1_1::Util>
+L<WebService::DS::SOP::Auth::V1_1::Request::DELETE>,
+L<WebService::DS::SOP::Auth::V1_1::Request::GET>,
+L<WebService::DS::SOP::Auth::V1_1::Request::POST>,
+L<WebService::DS::SOP::Auth::V1_1::Request::POST_JSON>,
+L<WebService::DS::SOP::Auth::V1_1::Request::PUT>,
+L<WebService::DS::SOP::Auth::V1_1::Request::PUT_JSON>,
+L<WebService::DS::SOP::Auth::V1_1::Util>
 
 =head1 LICENSE
 

--- a/lib/WebService/DS/SOP/Auth/V1_1/Request/DELETE.pm
+++ b/lib/WebService/DS/SOP/Auth/V1_1/Request/DELETE.pm
@@ -1,9 +1,9 @@
-package WebService::SOP::Auth::V1_1::Request::DELETE;
+package WebService::DS::SOP::Auth::V1_1::Request::DELETE;
 use strict;
 use warnings;
 use Carp ();
 use HTTP::Request::Common qw(DELETE);
-use WebService::SOP::Auth::V1_1::Util qw(create_signature);
+use WebService::DS::SOP::Auth::V1_1::Util qw(create_signature);
 
 sub create_request {
     my ($class, $uri, $params, $app_secret) = @_;
@@ -26,7 +26,7 @@ __END__
 
 =head1 NAME
 
-WebService::SOP::Auth::V1_1::Request::DELETE
+WebService::DS::SOP::Auth::V1_1::Request::DELETE
 
 =head1 DESCRIPTION
 

--- a/lib/WebService/DS/SOP/Auth/V1_1/Request/GET.pm
+++ b/lib/WebService/DS/SOP/Auth/V1_1/Request/GET.pm
@@ -1,9 +1,9 @@
-package WebService::SOP::Auth::V1_1::Request::GET;
+package WebService::DS::SOP::Auth::V1_1::Request::GET;
 use strict;
 use warnings;
 use Carp ();
 use HTTP::Request::Common qw(GET);
-use WebService::SOP::Auth::V1_1::Util qw(create_signature);
+use WebService::DS::SOP::Auth::V1_1::Util qw(create_signature);
 
 sub create_request {
     my ($class, $uri, $params, $app_secret) = @_;
@@ -26,7 +26,7 @@ __END__
 
 =head1 NAME
 
-WebService::SOP::Auth::V1_1::Request::GET
+WebService::DS::SOP::Auth::V1_1::Request::GET
 
 =head1 DESCRIPTION
 
@@ -42,7 +42,7 @@ Request parameters including signature are gathered as GET parameters.
 =head1 SEE ALSO
 
 L<HTTP::Request>
-L<WebService::SOP::Auth::V1_1>
+L<WebService::DS::SOP::Auth::V1_1>
 
 =head1 LICENSE
 

--- a/lib/WebService/DS/SOP/Auth/V1_1/Request/POST.pm
+++ b/lib/WebService/DS/SOP/Auth/V1_1/Request/POST.pm
@@ -1,9 +1,9 @@
-package WebService::SOP::Auth::V1_1::Request::POST;
+package WebService::DS::SOP::Auth::V1_1::Request::POST;
 use strict;
 use warnings;
 use Carp ();
 use HTTP::Request::Common qw(POST);
-use WebService::SOP::Auth::V1_1::Util qw(create_signature);
+use WebService::DS::SOP::Auth::V1_1::Util qw(create_signature);
 
 sub create_request {
     my ($class, $uri, $params, $app_secret) = @_;
@@ -25,7 +25,7 @@ __END__
 
 =head1 NAME
 
-WebService::SOP::Auth::V1_1::Request::POST
+WebService::DS::SOP::Auth::V1_1::Request::POST
 
 =head1 DESCRIPTION
 
@@ -41,7 +41,7 @@ Request parameters including signature are gathered as POST parameters.
 =head1 SEE ALSO
 
 L<HTTP::Request>
-L<WebService::SOP::Auth::V1_1>
+L<WebService::DS::SOP::Auth::V1_1>
 
 =head1 LICENSE
 

--- a/lib/WebService/DS/SOP/Auth/V1_1/Request/POST_JSON.pm
+++ b/lib/WebService/DS/SOP/Auth/V1_1/Request/POST_JSON.pm
@@ -1,10 +1,10 @@
-package WebService::SOP::Auth::V1_1::Request::PUT_JSON;
+package WebService::DS::SOP::Auth::V1_1::Request::POST_JSON;
 use strict;
 use warnings;
 use Carp ();
 use JSON::XS qw(encode_json);
-use HTTP::Request::Common qw(PUT);
-use WebService::SOP::Auth::V1_1::Util qw(create_signature);
+use HTTP::Request::Common qw(POST);
+use WebService::DS::SOP::Auth::V1_1::Util qw(create_signature);
 
 sub create_request {
     my ($class, $uri, $params, $app_secret) = @_;
@@ -15,9 +15,9 @@ sub create_request {
     my $content = encode_json($params);
     my $sig = create_signature($content, $app_secret);
 
-    my $req = PUT $uri, Content => $content;
+    my $req = POST $uri, Content => $content;
     $req->headers->header('content-type' => 'application/json');
-    $req->headers->header('x-sop-sig'    => $sig);
+    $req->headers->header('x-sop-sig' => $sig);
     $req;
 }
 
@@ -29,18 +29,23 @@ __END__
 
 =head1 NAME
 
-WebService::SOP::Auth::V1_1::Request::PUT_JSON
+WebService::DS::SOP::Auth::V1_1::Request::POST_JSON
 
 =head1 DESCRIPTION
 
-To create a valid L<HTTP::Request> object for C<PUT> request with content type C<application/json>.
+To create a valid L<HTTP::Request> object for given C<POST> request parameters to send JSON data.
 
-=head1 FUNCTIONS
+=head1 METHODS
 
-=head2 $class->create_request( URI $uri, Hash $params, Str $app_secret ) returns HTTP::Request
+=head2 $class->create_request( $uri, $params, $app_secret )
 
-Returns L<HTTP::Request> object for a PUT request with content-type C<application/json>,
-with signature in header C<X-Sop-Sig>.
+Returns L<HTTP::Request> object for a POST request.
+Request parameters are gathered as a JSON data in request body, while signature is added as request header C<X-Sop-Sig>.
+
+=head1 SEE ALSO
+
+L<HTTP::Request>
+L<WebService::DS::SOP::Auth::V1_1>
 
 =head1 LICENSE
 

--- a/lib/WebService/DS/SOP/Auth/V1_1/Request/PUT.pm
+++ b/lib/WebService/DS/SOP/Auth/V1_1/Request/PUT.pm
@@ -1,9 +1,9 @@
-package WebService::SOP::Auth::V1_1::Request::PUT;
+package WebService::DS::SOP::Auth::V1_1::Request::PUT;
 use strict;
 use warnings;
 use Carp ();
 use HTTP::Request::Common qw(PUT);
-use WebService::SOP::Auth::V1_1::Util qw(create_signature);
+use WebService::DS::SOP::Auth::V1_1::Util qw(create_signature);
 
 sub create_request {
     my ($class, $uri, $params, $app_secret) = @_;
@@ -22,7 +22,7 @@ __END__
 
 =head1 NAME
 
-WebService::SOP::Auth::V1_1::Request::PUT
+WebService::DS::SOP::Auth::V1_1::Request::PUT
 
 =head1 DESCRIPTION
 

--- a/lib/WebService/DS/SOP/Auth/V1_1/Request/PUT_JSON.pm
+++ b/lib/WebService/DS/SOP/Auth/V1_1/Request/PUT_JSON.pm
@@ -1,10 +1,10 @@
-package WebService::SOP::Auth::V1_1::Request::POST_JSON;
+package WebService::DS::SOP::Auth::V1_1::Request::PUT_JSON;
 use strict;
 use warnings;
 use Carp ();
 use JSON::XS qw(encode_json);
-use HTTP::Request::Common qw(POST);
-use WebService::SOP::Auth::V1_1::Util qw(create_signature);
+use HTTP::Request::Common qw(PUT);
+use WebService::DS::SOP::Auth::V1_1::Util qw(create_signature);
 
 sub create_request {
     my ($class, $uri, $params, $app_secret) = @_;
@@ -15,9 +15,9 @@ sub create_request {
     my $content = encode_json($params);
     my $sig = create_signature($content, $app_secret);
 
-    my $req = POST $uri, Content => $content;
+    my $req = PUT $uri, Content => $content;
     $req->headers->header('content-type' => 'application/json');
-    $req->headers->header('x-sop-sig' => $sig);
+    $req->headers->header('x-sop-sig'    => $sig);
     $req;
 }
 
@@ -29,23 +29,18 @@ __END__
 
 =head1 NAME
 
-WebService::SOP::Auth::V1_1::Request::POST_JSON
+WebService::DS::SOP::Auth::V1_1::Request::PUT_JSON
 
 =head1 DESCRIPTION
 
-To create a valid L<HTTP::Request> object for given C<POST> request parameters to send JSON data.
+To create a valid L<HTTP::Request> object for C<PUT> request with content type C<application/json>.
 
-=head1 METHODS
+=head1 FUNCTIONS
 
-=head2 $class->create_request( $uri, $params, $app_secret )
+=head2 $class->create_request( URI $uri, Hash $params, Str $app_secret ) returns HTTP::Request
 
-Returns L<HTTP::Request> object for a POST request.
-Request parameters are gathered as a JSON data in request body, while signature is added as request header C<X-Sop-Sig>.
-
-=head1 SEE ALSO
-
-L<HTTP::Request>
-L<WebService::SOP::Auth::V1_1>
+Returns L<HTTP::Request> object for a PUT request with content-type C<application/json>,
+with signature in header C<X-Sop-Sig>.
 
 =head1 LICENSE
 

--- a/lib/WebService/DS/SOP/Auth/V1_1/Util.pm
+++ b/lib/WebService/DS/SOP/Auth/V1_1/Util.pm
@@ -1,4 +1,4 @@
-package WebService::SOP::Auth::V1_1::Util;
+package WebService::DS::SOP::Auth::V1_1::Util;
 use strict;
 use warnings;
 use Carp ();
@@ -52,11 +52,11 @@ __END__
 
 =head1 NAME
 
-WebService::SOP::Auth::V1_1::Util - SOP version 1.1 authentication handy utilities
+WebService::DS::SOP::Auth::V1_1::Util - SOP version 1.1 authentication handy utilities
 
 =head1 SYNOPSIS
 
-    use WebService::SOP::Auth::V1_1 qw(create_signature is_signature_valid);
+    use WebService::DS::SOP::Auth::V1_1 qw(create_signature is_signature_valid);
 
 When creating a signature:
 
@@ -92,7 +92,7 @@ C<$time> is optional where C<time()> is used by default.
 
 =head1 SEE ALSO
 
-L<WebService::SOP::Auth::V1_1>
+L<WebService::DS::SOP::Auth::V1_1>
 
 =head1 LICENSE
 

--- a/lib/WebService/SOP/Auth/V1_1.pm
+++ b/lib/WebService/SOP/Auth/V1_1.pm
@@ -3,7 +3,7 @@ use 5.008001;
 use strict;
 use warnings;
 
-our $VERSION = "0.04";
+our $VERSION = "0.05";
 
 use Carp ();
 use URI;
@@ -43,7 +43,7 @@ sub create_request {
 
 sub verify_signature {
     my ($self, $sig, $params) = @_;
-    is_signature_valid($sig, $params, $self->app_secret, $self->time);
+    eval { is_signature_valid($sig, $params, $self->app_secret, $self->time); };
 }
 
 1;

--- a/minil.toml
+++ b/minil.toml
@@ -1,6 +1,6 @@
-name = "WebService-SOP-Auth-V1_1"
+name = "WebService-DS-SOP-Auth-V1_1"
 badges = ["travis"]
-authority="cpan:YOWCOW"
+authority="cpan:DSSYSTEM"
 
 module_maker="ModuleBuildTiny"
 

--- a/t/00_compile.t
+++ b/t/00_compile.t
@@ -2,11 +2,11 @@ use strict;
 use Test::More 0.98;
 
 use_ok $_ for qw(
-    WebService::SOP::Auth::V1_1
-    WebService::SOP::Auth::V1_1::Util
-    WebService::SOP::Auth::V1_1::Request::GET
-    WebService::SOP::Auth::V1_1::Request::POST
-    WebService::SOP::Auth::V1_1::Request::POST_JSON
+    WebService::DS::SOP::Auth::V1_1
+    WebService::DS::SOP::Auth::V1_1::Util
+    WebService::DS::SOP::Auth::V1_1::Request::GET
+    WebService::DS::SOP::Auth::V1_1::Request::POST
+    WebService::DS::SOP::Auth::V1_1::Request::POST_JSON
 );
 
 done_testing;

--- a/t/00_compile.t
+++ b/t/00_compile.t
@@ -1,6 +1,5 @@
 use strict;
 use Test::More 0.98;
-use Test::Pretty;
 
 use_ok $_ for qw(
     WebService::SOP::Auth::V1_1

--- a/t/01_util.t
+++ b/t/01_util.t
@@ -2,16 +2,16 @@ use strict;
 use warnings;
 use Test::Exception;
 use Test::More;
-use WebService::SOP::Auth::V1_1::Util;
+use WebService::DS::SOP::Auth::V1_1::Util;
 
 subtest 'Test create_string_from_hashref' => sub {
-    is WebService::SOP::Auth::V1_1::Util::create_string_from_hashref({
+    is WebService::DS::SOP::Auth::V1_1::Util::create_string_from_hashref({
         zzz => 'zzz',
         yyy => 'yyy',
         xxx => 'xxx',
     }) => 'xxx=xxx&yyy=yyy&zzz=zzz';
 
-    is WebService::SOP::Auth::V1_1::Util::create_string_from_hashref({
+    is WebService::DS::SOP::Auth::V1_1::Util::create_string_from_hashref({
         sop_xxx => 'sop_xxx',
         zzz => 'zzz',
         yyy => 'yyy',
@@ -19,7 +19,7 @@ subtest 'Test create_string_from_hashref' => sub {
     }) => 'xxx=xxx&yyy=yyy&zzz=zzz', 'prefix "sop_" is ignored for signature generation';
 
     throws_ok {
-        WebService::SOP::Auth::V1_1::Util::create_string_from_hashref({
+        WebService::DS::SOP::Auth::V1_1::Util::create_string_from_hashref({
             zzz => { aaa => 'aaa', },
         })
     } qr|not allowed|;
@@ -27,14 +27,14 @@ subtest 'Test create_string_from_hashref' => sub {
 
 subtest 'Test create_signature' => sub {
 
-    is WebService::SOP::Auth::V1_1::Util::create_signature({
+    is WebService::DS::SOP::Auth::V1_1::Util::create_signature({
             ccc => 'ccc',
             bbb => 'bbb',
             aaa => 'aaa',
             }, 'hogehoge')
        => '2fbfe87e54cc53036463633ef29beeaa4d740e435af586798917826d9e525112';
 
-    is WebService::SOP::Auth::V1_1::Util::create_signature({
+    is WebService::DS::SOP::Auth::V1_1::Util::create_signature({
             ccc => 'ccc',
             bbb => 'bbb',
             aaa => 'aaa',
@@ -42,7 +42,7 @@ subtest 'Test create_signature' => sub {
             }, 'hogehoge')
        => '2fbfe87e54cc53036463633ef29beeaa4d740e435af586798917826d9e525112';
 
-    is WebService::SOP::Auth::V1_1::Util::create_signature(
+    is WebService::DS::SOP::Auth::V1_1::Util::create_signature(
             '{"hoge":"fuga"}',
             'hogehoge')
        => 'dc76e675e2bcabc31182e33506f5b01ea7966a9c0640d335cc6cc551f0bb1bba';
@@ -51,15 +51,15 @@ subtest 'Test create_signature' => sub {
 subtest 'Test is_signature_valid' => sub {
 
     my $now = 100_000;
-    my $valid_for = $WebService::SOP::Auth::V1_1::Util::SIG_VALID_FOR_SEC;
+    my $valid_for = $WebService::DS::SOP::Auth::V1_1::Util::SIG_VALID_FOR_SEC;
 
     subtest 'No `time` in params' => sub {
         my $params = { aaa => 'aaa', bbb => 'bbb', };
-        my $sig = WebService::SOP::Auth::V1_1::Util::create_signature(
+        my $sig = WebService::DS::SOP::Auth::V1_1::Util::create_signature(
             $params => 'hogehoge',
         );
 
-        ok ! WebService::SOP::Auth::V1_1::Util::is_signature_valid(
+        ok ! WebService::DS::SOP::Auth::V1_1::Util::is_signature_valid(
             $sig, $params, 'hogehoge',
         );
     };
@@ -67,11 +67,11 @@ subtest 'Test is_signature_valid' => sub {
     subtest 'Out of range time (too old)' => sub {
         my $time = $now - $valid_for - 1;
         my $params = { aaa => 'aaa', bbb => 'bbb', time => $time };
-        my $sig = WebService::SOP::Auth::V1_1::Util::create_signature(
+        my $sig = WebService::DS::SOP::Auth::V1_1::Util::create_signature(
             $params => 'hogehoge',
         );
 
-        ok ! WebService::SOP::Auth::V1_1::Util::is_signature_valid(
+        ok ! WebService::DS::SOP::Auth::V1_1::Util::is_signature_valid(
             $sig, $params, 'hogehoge', $now,
         );
     };
@@ -79,11 +79,11 @@ subtest 'Test is_signature_valid' => sub {
     subtest 'In range (lower limit)' => sub {
         my $time = $now - $valid_for;
         my $params = { aaa => 'aaa', bbb => 'bbb', time => $time };
-        my $sig = WebService::SOP::Auth::V1_1::Util::create_signature(
+        my $sig = WebService::DS::SOP::Auth::V1_1::Util::create_signature(
             $params => 'hogehoge',
         );
 
-        ok WebService::SOP::Auth::V1_1::Util::is_signature_valid(
+        ok WebService::DS::SOP::Auth::V1_1::Util::is_signature_valid(
             $sig, $params, 'hogehoge', $now,
         );
     };
@@ -91,11 +91,11 @@ subtest 'Test is_signature_valid' => sub {
     subtest 'In range (wrong sig value)' => sub {
         my $time = $now;
         my $params = { aaa => 'aaa', bbb => 'bbb', time => $time };
-        my $sig = WebService::SOP::Auth::V1_1::Util::create_signature(
+        my $sig = WebService::DS::SOP::Auth::V1_1::Util::create_signature(
             $params => 'hogehoge',
         );
 
-        ok ! WebService::SOP::Auth::V1_1::Util::is_signature_valid(
+        ok ! WebService::DS::SOP::Auth::V1_1::Util::is_signature_valid(
             $sig. 'x', $params, 'hogehoge', $now,
         );
     };
@@ -103,11 +103,11 @@ subtest 'Test is_signature_valid' => sub {
     subtest 'In range (upper limit)' => sub {
         my $time = $now + $valid_for;
         my $params = { aaa => 'aaa', bbb => 'bbb', time => $time };
-        my $sig = WebService::SOP::Auth::V1_1::Util::create_signature(
+        my $sig = WebService::DS::SOP::Auth::V1_1::Util::create_signature(
             $params => 'hogehoge',
         );
 
-        ok WebService::SOP::Auth::V1_1::Util::is_signature_valid(
+        ok WebService::DS::SOP::Auth::V1_1::Util::is_signature_valid(
             $sig, $params, 'hogehoge', $now,
         );
     };
@@ -115,18 +115,18 @@ subtest 'Test is_signature_valid' => sub {
     subtest 'Out of range (too new)' => sub {
         my $time = $now + $valid_for + 1;
         my $params = { aaa => 'aaa', bbb => 'bbb', time => $time };
-        my $sig = WebService::SOP::Auth::V1_1::Util::create_signature(
+        my $sig = WebService::DS::SOP::Auth::V1_1::Util::create_signature(
             $params => 'hogehoge',
         );
 
-        ok ! WebService::SOP::Auth::V1_1::Util::is_signature_valid(
+        ok ! WebService::DS::SOP::Auth::V1_1::Util::is_signature_valid(
             $sig, $params, 'hogehoge', $now,
         );
     };
 
     subtest 'Malformed JSON' => sub {
         dies_ok {
-            WebService::SOP::Auth::V1_1::Util::is_signature_valid(
+            WebService::DS::SOP::Auth::V1_1::Util::is_signature_valid(
                 'signature',
                 '{"mal":"formed"',
                 'hogehoge',

--- a/t/01_util.t
+++ b/t/01_util.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use Test::Exception;
 use Test::More;
-use Test::Pretty;
 use WebService::SOP::Auth::V1_1::Util;
 
 subtest 'Test create_string_from_hashref' => sub {

--- a/t/02_instance.t
+++ b/t/02_instance.t
@@ -4,9 +4,9 @@ use JSON::XS qw(decode_json);
 use Test::Exception;
 use Test::Mock::Guard;
 use Test::More;
-use WebService::SOP::Auth::V1_1;
+use WebService::DS::SOP::Auth::V1_1;
 
-my $class = 'WebService::SOP::Auth::V1_1';
+my $class = 'WebService::DS::SOP::Auth::V1_1';
 
 subtest 'Test new w/o required params' => sub {
     throws_ok { $class->new } qr|Missing required parameter|;
@@ -184,7 +184,7 @@ subtest 'Test verify_request' => sub {
 
 subtest 'Test verify_signature error' => sub {
     my $guard = mock_guard(
-        'WebService::SOP::Auth::V1_1::Util' => {
+        'WebService::DS::SOP::Auth::V1_1::Util' => {
             is_signature_valid => sub { die 'Error'; },
         },
     );

--- a/t/02_instance.t
+++ b/t/02_instance.t
@@ -4,7 +4,6 @@ use JSON::XS qw(decode_json);
 use Test::Exception;
 use Test::Mock::Guard;
 use Test::More;
-use Test::Pretty;
 use WebService::SOP::Auth::V1_1;
 
 my $class = 'WebService::SOP::Auth::V1_1';
@@ -180,6 +179,26 @@ subtest 'Test verify_request' => sub {
             hoge   => 'fuga',
             time   => '1234',
             };
+    };
+};
+
+subtest 'Test verify_signature error' => sub {
+    my $guard = mock_guard(
+        'WebService::SOP::Auth::V1_1::Util' => {
+            is_signature_valid => sub { die 'Error'; },
+        },
+    );
+
+    my $auth = $class->new(
+        {   app_id     => '1',
+            app_secret => 'hogehoge',
+            time       => '1234',
+        }
+    );
+
+    lives_ok {
+        my $valid = $auth->verify_signature('test', {});
+        is $valid, undef;
     };
 };
 

--- a/t/request/delete.t
+++ b/t/request/delete.t
@@ -3,9 +3,9 @@ use warnings;
 use Test::Exception;
 use Test::More;
 use URI;
-use WebService::SOP::Auth::V1_1::Util qw(create_signature);
+use WebService::DS::SOP::Auth::V1_1::Util qw(create_signature);
 
-my $class = 'WebService::SOP::Auth::V1_1::Request::DELETE';
+my $class = 'WebService::DS::SOP::Auth::V1_1::Request::DELETE';
 
 use_ok $class;
 can_ok $class, 'create_request';

--- a/t/request/delete.t
+++ b/t/request/delete.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use Test::Exception;
 use Test::More;
-use Test::Pretty;
 use URI;
 use WebService::SOP::Auth::V1_1::Util qw(create_signature);
 

--- a/t/request/get.t
+++ b/t/request/get.t
@@ -3,9 +3,9 @@ use warnings;
 use Test::Exception;
 use Test::More;
 use URI;
-use WebService::SOP::Auth::V1_1::Request::GET;
+use WebService::DS::SOP::Auth::V1_1::Request::GET;
 
-my $class = 'WebService::SOP::Auth::V1_1::Request::GET';
+my $class = 'WebService::DS::SOP::Auth::V1_1::Request::GET';
 
 subtest 'Test create_request fail' => sub {
     my $uri = URI->new('http://hoge/get');

--- a/t/request/get.t
+++ b/t/request/get.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use Test::Exception;
 use Test::More;
-use Test::Pretty;
 use URI;
 use WebService::SOP::Auth::V1_1::Request::GET;
 

--- a/t/request/post-json.t
+++ b/t/request/post-json.t
@@ -5,9 +5,9 @@ use Test::Exception;
 use Test::Mock::Guard;
 use Test::More;
 use URI;
-use WebService::SOP::Auth::V1_1::Request::POST_JSON;
+use WebService::DS::SOP::Auth::V1_1::Request::POST_JSON;
 
-my $class = 'WebService::SOP::Auth::V1_1::Request::POST_JSON';
+my $class = 'WebService::DS::SOP::Auth::V1_1::Request::POST_JSON';
 
 subtest 'Test create_request fail' => sub {
     my $uri = URI->new('http://hoge/get');

--- a/t/request/post-json.t
+++ b/t/request/post-json.t
@@ -4,7 +4,6 @@ use JSON::XS qw(decode_json);
 use Test::Exception;
 use Test::Mock::Guard;
 use Test::More;
-use Test::Pretty;
 use URI;
 use WebService::SOP::Auth::V1_1::Request::POST_JSON;
 

--- a/t/request/post.t
+++ b/t/request/post.t
@@ -3,9 +3,9 @@ use warnings;
 use Test::Exception;
 use Test::More;
 use URI;
-use WebService::SOP::Auth::V1_1::Request::POST;
+use WebService::DS::SOP::Auth::V1_1::Request::POST;
 
-my $class = 'WebService::SOP::Auth::V1_1::Request::POST';
+my $class = 'WebService::DS::SOP::Auth::V1_1::Request::POST';
 
 subtest 'Test create_request fail' => sub {
     my $uri = URI->new('http://hoge/get');

--- a/t/request/post.t
+++ b/t/request/post.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use Test::Exception;
 use Test::More;
-use Test::Pretty;
 use URI;
 use WebService::SOP::Auth::V1_1::Request::POST;
 

--- a/t/request/put-json.t
+++ b/t/request/put-json.t
@@ -3,7 +3,6 @@ use warnings;
 use JSON::XS;
 use Test::Exception;
 use Test::More;
-use Test::Pretty;
 use WebService::SOP::Auth::V1_1::Util qw(create_signature);
 
 my $class = 'WebService::SOP::Auth::V1_1::Request::PUT_JSON';

--- a/t/request/put-json.t
+++ b/t/request/put-json.t
@@ -3,9 +3,9 @@ use warnings;
 use JSON::XS;
 use Test::Exception;
 use Test::More;
-use WebService::SOP::Auth::V1_1::Util qw(create_signature);
+use WebService::DS::SOP::Auth::V1_1::Util qw(create_signature);
 
-my $class = 'WebService::SOP::Auth::V1_1::Request::PUT_JSON';
+my $class = 'WebService::DS::SOP::Auth::V1_1::Request::PUT_JSON';
 
 use_ok $class;
 can_ok $class, 'create_request';

--- a/t/request/put.t
+++ b/t/request/put.t
@@ -3,9 +3,9 @@ use warnings;
 use Test::Exception;
 use Test::More;
 use URI;
-use WebService::SOP::Auth::V1_1::Util qw(create_signature);
+use WebService::DS::SOP::Auth::V1_1::Util qw(create_signature);
 
-my $class = 'WebService::SOP::Auth::V1_1::Request::PUT';
+my $class = 'WebService::DS::SOP::Auth::V1_1::Request::PUT';
 
 use_ok $class;
 can_ok $class, 'create_request';

--- a/t/request/put.t
+++ b/t/request/put.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use Test::Exception;
 use Test::More;
-use Test::Pretty;
 use URI;
 use WebService::SOP::Auth::V1_1::Util qw(create_signature);
 


### PR DESCRIPTION
In some cases, in the verifying_signature function, when receiving request parameters that cannot be processed, an exception will be occured. The actual situation is that signature verification cannot be completed. When an exception occurs, all exceptions will be caught and a verification failure will be returned.